### PR TITLE
Bug fixes:

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -302,7 +302,12 @@ function isRootLevelProjectionNode(tNode: TNode): boolean {
 function isDroppedProjectedNode(tNode: TNode): boolean {
   let currentTNode = tNode;
   let seenComponentHost = false;
-  while (currentTNode !== null) {
+  // The `currentTNode` becomes `undefined` in some cases
+  // (despite the typings saying it can only be `null`), so we
+  // take both `null` and `undefined` into account.
+  // FIXME: identify when `currentTNode` becomes `undefined` and
+  // switch to strict check (`!== null`).
+  while (currentTNode != null) {
     if (isComponentHost(currentTNode)) {
       seenComponentHost = true;
       break;

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -174,13 +174,15 @@ export function validateMatchingNode(
     isViewContainerAnchor = false): void {
   if (node.nodeType !== nodeType ||
       (node.nodeType === Node.ELEMENT_NODE &&
-       (node as HTMLElement).tagName.toLowerCase() !== tagName)) {
+       (node as HTMLElement).tagName.toLowerCase() !== tagName?.toLowerCase())) {
     const expectedNode = shortRNodeDescription(nodeType, tagName, null);
     const actualNode = shortRNodeDescription(
         node.nodeType, (node as HTMLElement).tagName ?? null,
         (node as HTMLElement).textContent ?? null);
     const header = `During hydration Angular expected ` +
         `${expectedNode} but found ${actualNode}.\n\n`;
+    const note = 'Note: attributes are only displayed to better represent the DOM' +
+        ' but have no effect on hydration mismatches.\n\n';
     const expected = `Angular expected this DOM:\n\n${
         describeExpectedDom(lView, tNode, isViewContainerAnchor)}\n\n`;
     const actual = `Actual DOM is:\n\n${describeActualDom(node)}\n\n`;
@@ -190,7 +192,7 @@ export function validateMatchingNode(
     const footer = getHydrationErrorFooter(componentClassName);
 
     // TODO: use RuntimeError instead.
-    throw new Error(header + expected + actual + footer);
+    throw new Error(header + note + expected + actual + footer);
   }
 }
 


### PR DESCRIPTION
Fix error when currentTNode.parent becomes undefined Add detail to mismatch error to clarify that attributes are irrelevant to the diff Ensure mismatch tags are both lower case